### PR TITLE
Add `yarn start` instruction and fix API server port conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ The IRMA app manages the user's IRMA attributes: receiving new attributes, selec
     cd $GOPATH/github.com/privacybydesign/irma_mobile
     yarn
     ```
+- Start the React Native development server and forward connections from ADB:
+    ```
+    yarn start
+    adb reverse tcp:8081 tcp:8082
+    ```
 - Start the app in debug mode:
     ```
     yarn android

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "eslint-plugin-react": "^7.4.0"
   },
   "scripts": {
-    "start": "react-native start",
+    "start": "react-native start --port 8082",
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "test": "node node_modules/jest/bin/jest.js --watch"


### PR DESCRIPTION
Without `yarn start` and a port forward, the app won't start.

See: https://github.com/facebook/react-native/issues/9145 (the `--port` flag is very new)