### PR TITLE
[UPDATE] Updated react-native to 0.57.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "moment": "^2.22.1",
     "native-base": "^2.7.2",
     "react": "^16.3.2",
-    "react-native": "^0.55.3",
+    "react-native": "^0.57.1",
     "react-native-camera": "https://github.com/react-native-community/react-native-camera.git#68011136282ace1a8e6550d687cafeaf02dc8b9c",
     "react-native-fs": "^2.9.12",
     "react-native-hyperlink": "^0.0.12",


### PR DESCRIPTION
To address the [issue #36]( https://github.com/privacybydesign/irma_mobile/issues/36 ) react-native should be updated at least to 0.57.1