### PR TITLE
fix: don't create second CredentialDashboard on mobile sessions when one already exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ const handleUrl = (event) => {
   if (!sessionPointer)
     return;
 
-  startSessionAndNavigate({sessionPointer, exitAfter: true, setRoot: true});
+  startSessionAndNavigate({sessionPointer, exitAfter: true, setRoot: false});
 };
 
 // Sets the initial screen as soon as the irmagobridge enrollment reducer


### PR DESCRIPTION
This should fix #50 and #53.