### PR TITLE
Client is initialized twice fix

### DIFF
--- a/irmagobridge/bridge.go
+++ b/irmagobridge/bridge.go
@@ -42,6 +42,11 @@ func Start(givenBridge IrmaBridge, appDataPath string, assetsPath string) {
 
 func recoveredStart(givenBridge IrmaBridge, appDataPath string, assetsPath string) {
 	bridge = givenBridge
+	// Check whether recoveredStart has been executed before
+	if client != nil {
+		logDebug("Client already initialized, skipping recoveredStart")
+		return
+	}
 
 	// Check for user data directory, and create version-specific directory
 	exists, err := pathExists(appDataPath)


### PR DESCRIPTION
This fix prevents that the client is initialized twice. This led to the error that the database cannot be opened the second time, because it was still open in the first instance.