### PR TITLE
update dutch translation for remove account confirmation message

### DIFF
--- a/lib/i18n/nl.js
+++ b/lib/i18n/nl.js
@@ -228,7 +228,7 @@ export default {
     deleteAll: {
       menu: 'IRMA account verwijderen',
       title: 'IRMA account verwijderen?',
-      message: 'Weet u zeker dat u al uw IRMA account en alle attributen permanent wilt verwijderen?',
+      message: 'Weet u zeker dat u uw IRMA account en al uw attributen permanent wilt verwijderen?',
       ok: 'Verwijderen',
       cancel: 'Annuleren',
     },


### PR DESCRIPTION
Bring delete irma account confirmation text in line with English text and correct dutch grammar.
Closes #104 https://github.com/privacybydesign/irma_mobile/issues/104
