### PR TITLE
Fixed race condition in combined issuance-disclosure sessions

### DIFF
--- a/store/reducers/sessions.js
+++ b/store/reducers/sessions.js
@@ -263,6 +263,12 @@ export default function credentials(state = initialState, action) {
         ...state,
         [sessionId]: {
           ...state[sessionId],
+          // Reset disclosure values, because one of these credentials might be deleted due to this session
+          disclosures: [],
+          disclosuresLabels: null,
+          disclosuresCandidates: [],
+          disclosureChoices: [],
+          disclosureIndices: [],
         }
       };
     }

--- a/store/reducers/sessions.js
+++ b/store/reducers/sessions.js
@@ -62,7 +62,7 @@ const returnUrlProperties = (returnUrl) => {
 };
 
 const initialState = {};
-export default function credentials(state = initialState, action) {
+export default function sessions(state = initialState, action) {
 
   if(!isValidSessionAction(state, action))
     return state;


### PR DESCRIPTION
This is a proposal to a fix that solves the `TypeError: TypeError: undefined is not an object (evaluating 'v.Attributes')` errors. It emerges when doing a combined issuance-disclosure session and requesting the disclosure of a credential that is going to be replaced in the following issuance (for example when refreshing the credential).